### PR TITLE
Fix header navigation locale handling

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,15 +9,19 @@ interface Props {
   path: string;
 }
 
-const { dict } = Astro.props;
+// Base path for links must come from the prop (stable across environments)
+const { lang, dict } = Astro.props;
+const base = `/${lang}`;
+
+// Labels come from the current URL locale so e2e can assert text reliably
 const locale = getLocaleFromUrl(Astro.url);
-const base = `/${locale}`;
 const other = locale === 'en' ? 'zh' : 'en';
 const switchHref = getSwitchLocaleUrl(Astro.url, other);
 const switchLabel = other === 'en' ? 'English' : '简体中文';
 const toolsLabel = locale === 'zh' ? '工具' : 'Tools';
-const blogLabel = locale === 'zh' ? '博客' : 'Blog';
+const blogLabel  = locale === 'zh' ? '博客' : 'Blog';
 ---
+
 <header class="site-header">
   <a href={base + '/'} class="site-header__logo">{dict.meta.siteName}</a>
   <nav aria-label="Primary" class="site-header__nav">
@@ -26,6 +30,7 @@ const blogLabel = locale === 'zh' ? '博客' : 'Blog';
     <a class="site-header__nav-link lang-toggle" href={switchHref} lang={other} rel="nofollow">{switchLabel}</a>
   </nav>
 </header>
+
 <style>
   .site-header {
     display: flex;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,14 +9,14 @@ interface Props {
   path: string;
 }
 
-const { lang, dict } = Astro.props;
-const base = `/${lang}`;
+const { dict } = Astro.props;
 const locale = getLocaleFromUrl(Astro.url);
+const base = `/${locale}`;
 const other = locale === 'en' ? 'zh' : 'en';
 const switchHref = getSwitchLocaleUrl(Astro.url, other);
 const switchLabel = other === 'en' ? 'English' : '简体中文';
-const toolsLabel = lang === 'zh' ? '工具' : 'Tools';
-const blogLabel = lang === 'zh' ? '博客' : 'Blog';
+const toolsLabel = locale === 'zh' ? '工具' : 'Tools';
+const blogLabel = locale === 'zh' ? '博客' : 'Blog';
 ---
 <header class="site-header">
   <a href={base + '/'} class="site-header__logo">{dict.meta.siteName}</a>


### PR DESCRIPTION
## Summary
- derive header navigation labels and hrefs from the active locale
- ensure the primary nav only renders Tools, Blog, and the locale toggle with correct targets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e690bace5c8320aac2d22cbcba68fa