### PR TITLE
feat: add Text formatter tool (en/zh) with e2e

### DIFF
--- a/e2e/text.spec.ts
+++ b/e2e/text.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { basePath } from '../project.config.js';
+
+const locales = ['en', 'zh'] as const;
+const normalizedBase = basePath.endsWith('/') ? basePath : `${basePath}/`;
+
+const resolvePath = (path: string) => {
+  const trimmed = path.startsWith('/') ? path.slice(1) : path;
+  if (!trimmed) return normalizedBase === '/' ? '/' : normalizedBase;
+  return normalizedBase === '/' ? `/${trimmed}` : `${normalizedBase}${trimmed}`;
+};
+
+for (const locale of locales) {
+  test(`Text formatter works for ${locale}`, async ({ page }) => {
+    page.on('console', (msg) => {
+      console.log(`[browser:${msg.type()}] ${msg.text()}`);
+    });
+    page.on('pageerror', (err) => {
+      console.log(`[pageerror] ${err?.message || String(err)}`);
+    });
+
+    await page.goto(resolvePath(`/${locale}/tools/text/`));
+    await page.waitForLoadState('domcontentloaded');
+
+    const input = page.locator('#tf-input');
+    await input.fill('hello   world\n\nApple\nbanana\napple\n');
+
+    const toggles = ['#op-trim', '#op-collapse', '#op-rmblank', '#op-dedupe'];
+    for (const selector of toggles) {
+      await page.locator(selector).check();
+    }
+
+    await page.locator('#op-case').selectOption('upper');
+    await page.locator('#op-sort').selectOption('asc');
+
+    await page.locator('#btn-format').click();
+
+    await page.waitForFunction(
+      () => document.body.getAttribute('data-text-ready') === 'true',
+      { timeout: 10_000 }
+    );
+
+    const preview = page.locator('#tf-preview pre');
+    await expect(preview).toHaveText('APPLE\nBANANA\nHELLO WORLD');
+
+    await expect(page.locator('#btn-copy')).not.toBeDisabled();
+    await expect(page.locator('#btn-download')).not.toBeDisabled();
+  });
+}

--- a/src/i18n/dict/en.ts
+++ b/src/i18n/dict/en.ts
@@ -16,6 +16,29 @@ const dict = {
   tools: {
     heading: 'Featured tools',
     intro: 'A taste of the utilities available in this starter project.',
+    text: {
+      title: 'Text formatter',
+      subtitle: 'Tidy up text snippets with quick transformations.',
+      description: 'Trim, collapse spaces, dedupe lines, change case, sort, and export.',
+      input: 'Input',
+      placeholder: 'Paste text here…',
+      trim: 'Trim ends',
+      collapse: 'Collapse spaces',
+      removeBlank: 'Remove blank lines',
+      dedupe: 'Deduplicate lines',
+      case: 'Case',
+      caseNone: 'Keep',
+      caseUpper: 'UPPER',
+      caseLower: 'lower',
+      caseTitle: 'Title Case',
+      sort: 'Sort lines',
+      sortNone: 'Keep',
+      sortAsc: 'A → Z',
+      sortDesc: 'Z → A',
+      format: 'Format',
+      copy: 'Copy',
+      ariaPreview: 'Preview of formatted text'
+    },
     qr: {
       title: 'QR Code Generator',
       subtitle: 'Create QR codes entirely in your browser and download as PNG / SVG.',
@@ -42,7 +65,8 @@ const dict = {
     },
     {
       title: 'Text formatter',
-      description: 'Tidy up text snippets with quick transformations.'
+      description: 'Trim, collapse spaces, dedupe lines, change case, sort, and export.',
+      slug: 'text'
     },
     {
       title: 'QR Code Generator',

--- a/src/i18n/dict/zh.ts
+++ b/src/i18n/dict/zh.ts
@@ -18,6 +18,29 @@ const dict: Dictionary = {
   tools: {
     heading: '工具目录',
     intro: '展示此模版中可扩展的几个小功能。',
+    text: {
+      title: '文本整理',
+      subtitle: '用简单操作快速规整文本片段。',
+      description: '支持去首尾空白、压缩空格、去空行、去重、大小写转换、排序与导出。',
+      input: '输入',
+      placeholder: '在此粘贴文本…',
+      trim: '去首尾空白',
+      collapse: '压缩空格',
+      removeBlank: '去空行',
+      dedupe: '去重（按行）',
+      case: '大小写',
+      caseNone: '保持不变',
+      caseUpper: '全大写',
+      caseLower: '全小写',
+      caseTitle: '标题式',
+      sort: '按行排序',
+      sortNone: '保持不变',
+      sortAsc: '升序（A→Z）',
+      sortDesc: '降序（Z→A）',
+      format: '整理',
+      copy: '复制',
+      ariaPreview: '已整理文本的预览'
+    },
     qr: {
       title: '二维码生成器',
       subtitle: '在浏览器本地生成二维码，并下载为 PNG / SVG。',
@@ -44,7 +67,8 @@ const dict: Dictionary = {
     },
     {
       title: '文本整理',
-      description: '用简单操作就能格式化文本内容。'
+      description: '支持去首尾空白、压缩空格、去空行、去重、大小写转换、排序与导出。',
+      slug: 'text'
     },
     {
       title: '二维码生成器',

--- a/src/pages/[lang]/tools/text.astro
+++ b/src/pages/[lang]/tools/text.astro
@@ -1,0 +1,453 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { getDictionary, isLocale, type Locale } from '../../../i18n';
+import { defaultLocale } from '../../../i18n/config';
+import { withBase } from '../../../utils/paths';
+
+export const prerender = true;
+
+export function getStaticPaths() {
+  return ['en', 'zh'].map((lang) => ({ params: { lang } }));
+}
+
+const { lang } = Astro.params;
+
+if (!isLocale(lang)) {
+  return Astro.redirect(withBase(`/${defaultLocale}/`));
+}
+
+const locale = lang as Locale;
+const dict = (await getDictionary(locale)) as any;
+const textDict = dict?.tools?.text ?? {};
+---
+
+<BaseLayout
+  lang={locale}
+  dict={dict}
+  title={textDict?.title}
+  description={textDict?.description}
+>
+  <section class="tf-section">
+    <header class="tf-header">
+      <h1>{textDict?.title}</h1>
+      <p>{textDict?.subtitle}</p>
+    </header>
+    <p class="tf-description">{textDict?.description}</p>
+
+    <div class="tf-grid">
+      <form class="tf-card" onSubmit={(event) => event.preventDefault()}>
+        <label class="tf-field">
+          <span class="tf-label">{textDict?.input}</span>
+          <textarea
+            id="tf-input"
+            placeholder={textDict?.placeholder}
+            rows={12}
+          ></textarea>
+        </label>
+
+        <div class="tf-options">
+          <label class="tf-option"><input id="op-trim" type="checkbox" /> {textDict?.trim}</label>
+          <label class="tf-option"><input id="op-collapse" type="checkbox" /> {textDict?.collapse}</label>
+          <label class="tf-option"><input id="op-rmblank" type="checkbox" /> {textDict?.removeBlank}</label>
+          <label class="tf-option"><input id="op-dedupe" type="checkbox" /> {textDict?.dedupe}</label>
+        </div>
+
+        <div class="tf-selects">
+          <label class="tf-select">
+            <span class="tf-label">{textDict?.case}</span>
+            <select id="op-case">
+              <option value="none">{textDict?.caseNone}</option>
+              <option value="upper">{textDict?.caseUpper}</option>
+              <option value="lower">{textDict?.caseLower}</option>
+              <option value="title">{textDict?.caseTitle}</option>
+            </select>
+          </label>
+          <label class="tf-select">
+            <span class="tf-label">{textDict?.sort}</span>
+            <select id="op-sort">
+              <option value="none">{textDict?.sortNone}</option>
+              <option value="asc">{textDict?.sortAsc}</option>
+              <option value="desc">{textDict?.sortDesc}</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="tf-actions">
+          <button id="btn-format" type="button">{textDict?.format}</button>
+          <button id="btn-copy" type="button" disabled>{textDict?.copy}</button>
+          <button id="btn-download" type="button" disabled>TXT</button>
+        </div>
+        <p id="tf-msg" class="tf-status" aria-live="polite"></p>
+      </form>
+
+      <div class="tf-preview-card">
+        <div
+          id="tf-preview"
+          class="tf-preview"
+          aria-live="polite"
+          data-label={textDict?.ariaPreview}
+        ></div>
+      </div>
+    </div>
+  </section>
+
+  <style>
+    .tf-section {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      padding: 2rem 0;
+    }
+
+    .tf-header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .tf-header h1 {
+      margin: 0;
+      font-size: 2rem;
+    }
+
+    .tf-header p {
+      margin: 0;
+      max-width: 40rem;
+      color: rgba(255, 255, 255, 0.8);
+    }
+
+    .tf-description {
+      margin: 0;
+      max-width: 42rem;
+      color: rgba(255, 255, 255, 0.75);
+    }
+
+    .tf-grid {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .tf-card,
+    .tf-preview-card {
+      background: rgba(148, 163, 184, 0.15);
+      backdrop-filter: blur(4px);
+      border-radius: 1rem;
+      padding: 1.5rem;
+    }
+
+    .tf-card {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      color-scheme: light;
+      color: #0f172a;
+    }
+
+    .tf-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .tf-label {
+      font-weight: 600;
+      color: #111827;
+    }
+
+    textarea {
+      width: 100%;
+      min-height: 12rem;
+      padding: 0.75rem;
+      border-radius: 0.75rem;
+      border: 1px solid rgba(15, 23, 42, 0.15);
+      background: #ffffff;
+      color: #0f172a;
+      font: inherit;
+      resize: vertical;
+    }
+
+    textarea::placeholder {
+      color: #475569;
+    }
+
+    .tf-options {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .tf-option {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: #111827;
+      font-size: 0.95rem;
+    }
+
+    .tf-option input[type='checkbox'] {
+      width: 1rem;
+      height: 1rem;
+    }
+
+    .tf-selects {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .tf-select {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    select {
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.75rem;
+      border: 1px solid rgba(15, 23, 42, 0.2);
+      background: #ffffff;
+      color: #0f172a;
+      font: inherit;
+    }
+
+    .tf-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .tf-actions button {
+      padding: 0.6rem 1.2rem;
+      border-radius: 999px;
+      border: none;
+      font-weight: 600;
+      cursor: pointer;
+      background: #1d4ed8;
+      color: #ffffff;
+      transition: opacity 0.2s ease;
+    }
+
+    .tf-actions button[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+      background: #64748b;
+    }
+
+    .tf-status {
+      min-height: 1rem;
+      margin: 0;
+      font-size: 0.9rem;
+      color: #0f172a;
+    }
+
+    .tf-preview-card {
+      min-height: 100%;
+    }
+
+    .tf-preview {
+      min-height: 12rem;
+      padding: 1rem;
+      border-radius: 0.75rem;
+      background: rgba(15, 23, 42, 0.15);
+      overflow: auto;
+      color: #0f172a;
+      font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas,
+        'Liberation Mono', 'Courier New', monospace;
+    }
+
+    .tf-preview pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    @media (max-width: 600px) {
+      .tf-header h1 {
+        font-size: 1.75rem;
+      }
+    }
+  </style>
+
+  <script type="module">
+    const byId = (id) => document.getElementById(id);
+    const input = /** @type {HTMLTextAreaElement | null} */ (byId('tf-input'));
+    const preview = byId('tf-preview');
+    const message = byId('tf-msg');
+    const btnFormat = byId('btn-format');
+    const btnCopy = byId('btn-copy');
+    const btnDownload = byId('btn-download');
+    const caseSelect = /** @type {HTMLSelectElement | null} */ (byId('op-case'));
+    const sortSelect = /** @type {HTMLSelectElement | null} */ (byId('op-sort'));
+    const trimCheckbox = /** @type {HTMLInputElement | null} */ (byId('op-trim'));
+    const collapseCheckbox = /** @type {HTMLInputElement | null} */ (byId('op-collapse'));
+    const blankCheckbox = /** @type {HTMLInputElement | null} */ (byId('op-rmblank'));
+    const dedupeCheckbox = /** @type {HTMLInputElement | null} */ (byId('op-dedupe'));
+    const previewLabel = preview?.dataset?.label || '';
+
+    const setReady = (ready) => {
+      if (ready) {
+        document.body.setAttribute('data-text-ready', 'true');
+      } else {
+        document.body.removeAttribute('data-text-ready');
+      }
+    };
+
+    const updateButtons = (enabled) => {
+      if (!btnCopy || !btnDownload) return;
+      if (enabled) {
+        btnCopy.removeAttribute('disabled');
+        btnDownload.removeAttribute('disabled');
+      } else {
+        btnCopy.setAttribute('disabled', '');
+        btnDownload.setAttribute('disabled', '');
+      }
+    };
+
+    const setMessage = (text) => {
+      if (message) {
+        message.textContent = text || '';
+      }
+    };
+
+    const toTitleCase = (value) => {
+      return value.replace(/\b([A-Za-z])([A-Za-z]*)/g, (_, first, rest) => {
+        return first.toUpperCase() + rest.toLowerCase();
+      });
+    };
+
+    const collapseLine = (line) => {
+      const normalized = line.replace(/\u00a0/g, ' ');
+      return normalized.replace(/[ \t]+/g, ' ');
+    };
+
+    const dedupeLines = (lines) => {
+      const seen = new Set();
+      const result = [];
+      for (const line of lines) {
+        if (!seen.has(line)) {
+          seen.add(line);
+          result.push(line);
+        }
+      }
+      return result;
+    };
+
+    const sortLines = (lines, mode) => {
+      if (mode === 'asc') {
+        return [...lines].sort((a, b) => a.localeCompare(b));
+      }
+      if (mode === 'desc') {
+        return [...lines].sort((a, b) => b.localeCompare(a));
+      }
+      return lines;
+    };
+
+    const formatValue = () => {
+      const raw = input?.value ?? '';
+      let text = raw;
+      if (trimCheckbox?.checked) {
+        text = text.trim();
+      }
+
+      let lines = text.split(/\r?\n/);
+
+      if (collapseCheckbox?.checked) {
+        lines = lines.map((line) => collapseLine(line));
+      }
+
+      if (blankCheckbox?.checked) {
+        lines = lines.filter((line) => line.trim().length > 0);
+      }
+
+      if (dedupeCheckbox?.checked) {
+        lines = dedupeLines(lines);
+      }
+
+      const caseMode = caseSelect?.value || 'none';
+      if (caseMode === 'upper') {
+        lines = lines.map((line) => line.toUpperCase());
+      } else if (caseMode === 'lower') {
+        lines = lines.map((line) => line.toLowerCase());
+      } else if (caseMode === 'title') {
+        lines = lines.map((line) => toTitleCase(line));
+      }
+
+      const sortMode = sortSelect?.value || 'none';
+      lines = sortLines(lines, sortMode);
+
+      const output = lines.join('\n');
+      return {
+        output,
+        hasContent: output.length > 0,
+      };
+    };
+
+    const renderOutput = (value) => {
+      if (!preview) return;
+      preview.innerHTML = '';
+      if (!value) return;
+      const pre = document.createElement('pre');
+      pre.textContent = value;
+      if (previewLabel) {
+        pre.setAttribute('aria-label', previewLabel);
+      }
+      preview.appendChild(pre);
+    };
+
+    btnFormat?.addEventListener('click', () => {
+      document.body.setAttribute('data-text-clicked', 'true');
+      setReady(false);
+      setMessage('');
+      const { output, hasContent } = formatValue();
+      renderOutput(output);
+      updateButtons(hasContent);
+      if (hasContent) {
+        setMessage(previewLabel);
+        setReady(true);
+      } else {
+        setMessage('');
+      }
+    });
+
+    btnCopy?.addEventListener('click', async () => {
+      if (btnCopy.hasAttribute('disabled')) return;
+      const text = preview?.querySelector('pre')?.textContent ?? '';
+      if (!text) return;
+      try {
+        await navigator.clipboard.writeText(text);
+        setMessage(btnCopy.textContent || '');
+      } catch (err) {
+        setMessage(String(err ?? ''));
+      }
+    });
+
+    btnDownload?.addEventListener('click', () => {
+      if (btnDownload.hasAttribute('disabled')) return;
+      const text = preview?.querySelector('pre')?.textContent ?? '';
+      if (!text) return;
+      const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = 'formatted.txt';
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+      setMessage(btnDownload.textContent || '');
+    });
+
+    if (input) {
+      input.addEventListener('input', () => {
+        if (!input.value) {
+          updateButtons(false);
+          setReady(false);
+          if (preview) {
+            preview.innerHTML = '';
+          }
+        }
+        setMessage('');
+      });
+    }
+  </script>
+</BaseLayout>


### PR DESCRIPTION
## What
- new text formatter tool with trim/collapse/remove blank/dedupe/case/sort/copy/download

## Testing
- npm run build
- npm test
- npm run e2e *(fails locally: Playwright browsers unavailable; tests assert DOM state via `data-text-ready` and preview content, with no download-path assertions so CI with browsers should pass.)*

## Notes
- All logic client-only; no external deps; dark-theme-friendly controls (`color-scheme: light`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6908bdc265848320a031d8bc8fb3827e)